### PR TITLE
Remove nodeSelector

### DIFF
--- a/install/edge-cloud-controller-manager-k3s-deployment.yaml
+++ b/install/edge-cloud-controller-manager-k3s-deployment.yaml
@@ -59,7 +59,3 @@ spec:
       # the taint may vary depending on your cluster setup
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
-      # this is to restrict CCM to only run on master nodes
-      # the node selector may vary depending on your cluster setup
-      nodeSelector:
-        node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Remove the master node selector so that it can run
on deployments without master-labeled nodes.
(like k3s with --disable-agent.)

From the commit log, I don't see why this selector was necessary
in the first place.  The all-in-one case mentioned in the commit
message should be fine without this selector.